### PR TITLE
Fix rollup warning messages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,20 +14,29 @@ export default {
       file: 'dist/timepicker.umd.js',
       name: 'timepicker',
       format: 'umd',
+      globals: {
+        react: "React",
+        "prop-types": "PropTypes",
+        "styled-components": "styled"
+      },
     },
     {
       file: 'dist/timepicker.es.js',
       name: 'timepicker',
       format: 'es',
-    }
+      globals: {
+        react: "React",
+        "prop-types": "PropTypes",
+        "styled-components": "styled"
+      },
+    },
   ],
   plugins: [
     babel({
       babelrc: false,
       exclude: 'node_modules/**',
       plugins: [
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-external-helpers'
+        '@babel/plugin-proposal-class-properties'
       ],
       presets: [['@babel/env', { modules: false }], '@babel/react']
     })


### PR DESCRIPTION
This fixes some warnings when using `yarn compile`.

Before:
<img width="888" alt="Bildschirmfoto 2022-03-15 um 10 27 22" src="https://user-images.githubusercontent.com/53489780/158347794-a44911c3-6b1b-43b5-aab5-2d337008e742.png">

After:
<img width="885" alt="Bildschirmfoto 2022-03-15 um 10 27 43" src="https://user-images.githubusercontent.com/53489780/158347835-c0f8c213-e37d-4492-b157-a1ac0c409011.png">
